### PR TITLE
Add WakaTime Github Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Waka Readme
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at 12am UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  update-readme:
+    name: Update this repo's README
+    runs-on: ubuntu-latest
+    steps:
+      - uses: athul/waka-readme@master
+        with:
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}


### PR DESCRIPTION
This adds a WakaTime Github Workflow for my personal README. This should auto-update the WakaTime graph (See README) every day at 12am. 

See https://github.com/athul/waka-readme for the walkthrough