### PR TITLE
Fix Octokit Client

### DIFF
--- a/game/octokit_client.rb
+++ b/game/octokit_client.rb
@@ -1,15 +1,9 @@
 require 'octokit'
 
 class OctokitClient
-  PREVIEW_HEADERS = [
-    ::Octokit::Preview::PREVIEW_TYPES[:reactions],
-    ::Octokit::Preview::PREVIEW_TYPES[:integrations]
-  ].freeze
-
   def initialize(github_token:, repository:, issue_number:)
     @octokit = Octokit::Client.new(access_token: github_token)
     @octokit.auto_paginate = true
-    @octokit.default_media_type = ::Octokit::Preview::PREVIEW_TYPES[:integrations]
     @repository = repository
     @issue_number = issue_number
   end
@@ -23,7 +17,7 @@ class OctokitClient
   end
 
   def add_reaction(reaction:)
-    @octokit.create_issue_reaction(@repository, @issue_number, reaction, {accept: PREVIEW_HEADERS})
+    @octokit.create_issue_reaction(@repository, @issue_number, reaction)
   end
 
   def close_issue


### PR DESCRIPTION
## What this PR accomplishes
Octokit client has a major breaking version that caused the Github action workflow to fail with the following error:

```
/will-r-wang/game/octokit_client.rb:5:in `<class:OctokitClient>':
uninitialized constant Octokit::Preview (NameError)
Error: Process completed with exit code 1.
```

This updates the client syntax to hopefully get it to work again. 🤞

## Before you deploy
- [x] I tophatted 🎩 or tested this change.
- [x] This PR is safe to rollback 🤒 .